### PR TITLE
Annemieke fliptool

### DIFF
--- a/test/test_geometry.py
+++ b/test/test_geometry.py
@@ -101,7 +101,7 @@ class TestTLine(unittest.TestCase):
         line = TLine([(0.0, 0.0), (1.0, 1.0), (2.0, 2.0), (2.0, 4.0), (4.0, 4.0)])
         flipped_line = line.get_flipped_line()
         
-        self.assertEqual(flipped_line,[(4.0, 4.0), (2.0, 4.0), (2.0, 2.0), (1.0, 1.0), (0.0, 0.0)])
+        self.assertEqual(flipped_line,((4.0, 4.0), (2.0, 4.0), (2.0, 2.0), (1.0, 1.0), (0.0, 0.0)))
         
 
 class TestTMultiLine(unittest.TestCase):

--- a/test/test_tool_dwp_tools.py
+++ b/test/test_tool_dwp_tools.py
@@ -87,8 +87,8 @@ class TestDWPTools(unittest.TestCase):
         self.assertEqual(len(flipped_line_col), 2)
         self.assertDictEqual(flipped_line_col[0]['geometry'],
                              {'type': 'MultiLineString',
-                              'coordinates': [[(4.0, 4.0), (2.0, 4.0), (2.0, 2.0)], 
-                                              [(1.0, 1.0), (0.0, 0.0)]]})
+                              'coordinates': [((4.0, 4.0), (2.0, 4.0), (2.0, 2.0)), 
+                                              ((1.0, 1.0), (0.0, 0.0))]})
         self.assertDictEqual(flipped_line_col[1]['geometry'],
                              {'type': 'LineString',
-                              'coordinates': [(1.0, 3.6), (1.0, 0.0)]})
+                              'coordinates': ((1.0, 3.6), (1.0, 0.0))})

--- a/test/test_tool_dwp_tools.py
+++ b/test/test_tool_dwp_tools.py
@@ -67,7 +67,7 @@ class TestDWPTools(unittest.TestCase):
         self.assertDictEqual(haakselijn_col[3]['properties'],
                              {'id': 4, 'name': 'line 2_p1'})
         
-    def test_get_flipped_line_singlepart(self):
+    def test_get_flipped_line(self):
         """test flip line"""
         
         line_col = MemCollection(geometry_type='MultiLinestring')
@@ -84,11 +84,11 @@ class TestDWPTools(unittest.TestCase):
 
         flipped_line_col = flip_lines(line_col)
         
-        self.assertEqual(len(flipped_line_col), 5)
+        self.assertEqual(len(flipped_line_col), 2)
         self.assertDictEqual(flipped_line_col[0]['geometry'],
-                             {'type': 'LineString',
-                              'coordinates': ([(4.0, 4.0), (2.0, 4.0), (2.0, 2.0)], 
-                                              [(1.0, 1.0), (0.0, 0.0)])})
+                             {'type': 'MultiLineString',
+                              'coordinates': [[(4.0, 4.0), (2.0, 4.0), (2.0, 2.0)], 
+                                              [(1.0, 1.0), (0.0, 0.0)]]})
         self.assertDictEqual(flipped_line_col[1]['geometry'],
                              {'type': 'LineString',
-                              'coordinates': ((1.0, 3.6), (1.0, 0.0))})
+                              'coordinates': [(1.0, 3.6), (1.0, 0.0)]})

--- a/tools/dwp_tools.py
+++ b/tools/dwp_tools.py
@@ -40,11 +40,18 @@ def flip_lines(collection):
     for feature in collection.filter():
         if type(feature['geometry']['coordinates'][0][0]) != tuple:
             line = TLine(feature['geometry']['coordinates'])
+            check = 'Tline'
         else:
             line = TMultiLineString(feature['geometry']['coordinates'])     
+            check = 'TMultiLineString'
         
-        line.get_flipped_line()
+        flipped_line = line.get_flipped_line()
         
-        line['geometry']['coordinates'] = l.coords
-        
+        if check == 'TMultiLineString':
+            line['geometry']['coordinates'] = []
+            for l in flipped_line.filter():
+                line['geometry']['coordinates'].extend(l.coords)
+        else:
+            line['geometry']['coordinates'] = flipped_line.coords
+    
     return collection

--- a/tools/dwp_tools.py
+++ b/tools/dwp_tools.py
@@ -37,7 +37,7 @@ def get_haakselijnen_on_points_on_line(line_col, point_col, copy_fields=list(),
 def flip_lines(collection):
     """ returns MemCollection with flipped lines"""    
     
-    for feature in collection.filter():
+    for feature in collection:
         if type(feature['geometry']['coordinates'][0][0]) != tuple:
             line = TLine(feature['geometry']['coordinates'])
             check = 'Tline'
@@ -45,13 +45,12 @@ def flip_lines(collection):
             line = TMultiLineString(feature['geometry']['coordinates'])     
             check = 'TMultiLineString'
         
+        print 'Gevonden lijnobject: ', line
+        
         flipped_line = line.get_flipped_line()
         
-        if check == 'TMultiLineString':
-            line['geometry']['coordinates'] = []
-            for l in flipped_line.filter():
-                line['geometry']['coordinates'].extend(l.coords)
-        else:
-            line['geometry']['coordinates'] = flipped_line.coords
-    
+        print 'Geflipte versie lijnobject', flipped_line
+
+        feature['geometry']['coordinates'] = flipped_line
+            
     return collection

--- a/tools/dwp_tools.py
+++ b/tools/dwp_tools.py
@@ -45,11 +45,7 @@ def flip_lines(collection):
             line = TMultiLineString(feature['geometry']['coordinates'])     
             check = 'TMultiLineString'
         
-        print 'Gevonden lijnobject: ', line
-        
         flipped_line = line.get_flipped_line()
-        
-        print 'Geflipte versie lijnobject', flipped_line
 
         feature['geometry']['coordinates'] = flipped_line
             

--- a/utils/geometry.py
+++ b/utils/geometry.py
@@ -244,14 +244,14 @@ class TLine(LineString):
         return: Tline in flipped direction
         """
 
-        flipped_line = []
+        flipped_line = []      
         
-        if hasattr(self, 'geoms'):
-            coords = []
+        if hasattr(self, 'geoms'):            
             for geom in self.geoms:
-                coords.insert(0,geom.coords)
-            flipped_line.insert(0,coords)
-            
+                coords = []
+                for p in geom.coords:
+                    coords.insert(0, p)
+                flipped_line.insert(0, coords)                                                
         else:
             for p in self.coords:
                 flipped_line.insert(0, p)        

--- a/utils/geometry.py
+++ b/utils/geometry.py
@@ -246,9 +246,16 @@ class TLine(LineString):
 
         flipped_line = []
         
-        for p in self.coords:
-            flipped_line.insert(0, p)
-
+        if hasattr(self, 'geoms'):
+            coords = []
+            for geom in self.geoms:
+                coords.insert(0,geom.coords)
+            flipped_line.insert(0,coords)
+            
+        else:
+            for p in self.coords:
+                flipped_line.insert(0, p)        
+        
         return flipped_line
     
     

--- a/utils/geometry.py
+++ b/utils/geometry.py
@@ -247,14 +247,10 @@ class TLine(LineString):
         flipped_line = []      
         
         if hasattr(self, 'geoms'):            
-            for geom in self.geoms:
-                coords = []
-                for p in geom.coords:
-                    coords.insert(0, p)
-                flipped_line.insert(0, coords)                                                
+            for geom in reversed(self.geoms):
+                flipped_line.append(tuple([p for p in reversed(geom.coords)]))                                                
         else:
-            for p in self.coords:
-                flipped_line.insert(0, p)        
+            flipped_line = tuple([p for p in reversed(self.coords)])      
         
         return flipped_line
     


### PR DESCRIPTION
Ik dacht problemen te hebben met de wijze waarop de multilinestring in de collection gedefinieerd wordt (kreeg [[(),()]] terug terwijl we eigenlijk [((),())] verwacht hadden), maar blijkt voor de uiteindelijke shape niets uit te maken.

Getest met de testdata: Test_kwaliteit.shp (in flipline.py staat de verwijzing naar deze testdata nog aan, dus nog niet goed aanroepbaar via Toolbox.... Toolbox moet ook nog aangepast worden op wijze invoer doelbestand)