### PR TITLE
Eline 2811

### DIFF
--- a/test/test_snap_points_to_line.py
+++ b/test/test_snap_points_to_line.py
@@ -92,3 +92,51 @@ class TestSnapPointToLine(unittest.TestCase):
         self.assertTupleEqual(point_dict[5]['geometry']['coordinates'], (0.75, 9.25))
 
         self.assertEqual(len(point_dict.items()), 4)
+
+
+class TestSnapPointToMultiLine(TestSnapPointToLine):
+
+    def setUp(self):
+        self.lines = MemCollection()
+
+        self.lines.writerecords([{
+            'geometry': {'type': 'MultiLineString', 'coordinates': [((0, 0), (0, 5)), ((0, 5), (0, 10))]},
+            'properties': {'lid': 1, 'name': 'line 3', 'nr': 2, 'direction': 1}
+        }, {
+            'geometry': {'type': 'MultiLineString', 'coordinates': [((0, 10), (5, 5)), ((5, 5), (10, 0))]},
+            'properties': {'lid': 2, 'name': 'line 4', 'nr': 1, 'direction': -1}
+        }])
+
+        self.points = MemCollection()
+
+        self.points.writerecords([{
+            'geometry': {'type': 'Point', 'coordinates': (0, 1)},
+            'properties': {'pid': 1}
+        }, {
+            'geometry': {'type': 'Point', 'coordinates': (-1, 2)},
+            'properties': {'pid': 2}
+        }, {
+            'geometry': {'type': 'Point', 'coordinates': (-2, 3)},
+            'properties': {'pid': 3}
+        }, {
+            'geometry': {'type': 'Point', 'coordinates': (6, 0)},
+            'properties': {'pid': 4}
+        }, {
+            'geometry': {'type': 'Point', 'coordinates': (0.5, 9)},
+            'properties': {'pid': 5}
+        }])
+
+    def test_snapctwo(self):
+        tolerance = 4
+        keep_unsnapped_points = False
+
+        snapped_points = snap_points_to_line(self.lines, self.points, tolerance, keep_unsnapped_points)
+        point_dict = {point['properties']['pid']: point for point in snapped_points}
+
+        self.assertAlmostEqual(point_dict[4]['geometry']['coordinates'][0], 8, places=8)
+        self.assertAlmostEqual(point_dict[4]['geometry']['coordinates'][1], 2, places=8)
+        self.assertTupleEqual(point_dict[5]['geometry']['coordinates'], (0.75, 9.25))
+
+        self.assertEqual(len(point_dict.items()), 5)
+
+        # TODO: Fix failing test_snapc for multilinestrings

--- a/tools/snap_points_to_line.py
+++ b/tools/snap_points_to_line.py
@@ -1,8 +1,8 @@
 from gistools.utils.collection import MemCollection
-from shapely.geometry import Point, LineString
+from shapely.geometry import Point, MultiLineString, LineString
 
 
-def snap_points_to_line(line_col, points_col, tolerance=0.01, keep_unsnapped_points=False):
+def snap_points_to_line(line_col, points_col, tolerance=0.01, keep_unsnapped_points=True):
     snapped_points_col = MemCollection(geometry_type='Point')
     snapped_points_list = []
 
@@ -22,7 +22,11 @@ def snap_points_to_line(line_col, points_col, tolerance=0.01, keep_unsnapped_poi
         nearest_line = None
 
         for line in lines:
-            line_geom = LineString(line['geometry']['coordinates'])
+            if line['geometry']['type'].lower() == 'multilinestring':
+                line_geom = MultiLineString(line['geometry']['coordinates'])
+            else:
+                line_geom = LineString(line['geometry']['coordinates'])
+
             new_distance = point_geom.distance(line_geom)
             if new_distance < distance:
                 distance = new_distance


### PR DESCRIPTION
Test test_snapc still fills on the rounding off. Will be looked at still. 

Contains the underlying code for the tool "Snap points to line"